### PR TITLE
made areaID optional

### DIFF
--- a/Sources/OpenWeatherKit/Internal/Models/APIWeatherAlerts.swift
+++ b/Sources/OpenWeatherKit/Internal/Models/APIWeatherAlerts.swift
@@ -25,7 +25,7 @@ struct APIWeatherAlerts: Codable, Equatable {
 struct APIAlertSummary: Codable, Equatable {
     let name: String
     let id: String
-    let areaID: String
+    let areaID: String?
     let areaName: String?
     let attributionURL: String
     let countryCode: String

--- a/Sources/OpenWeatherKit/Public/Characteristics/AlertSummary.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/AlertSummary.swift
@@ -12,7 +12,7 @@ import Foundation
 public struct AlertSummary: Codable, Equatable, Sendable {
     public var name: String
     public var id: String
-    public var areaID: String
+    public var areaID: String?
     public var areaName: String?
     public var attributionURL: String
     public var countryCode: String
@@ -33,7 +33,7 @@ public struct AlertSummary: Codable, Equatable, Sendable {
     public init(
         name: String,
         id: String,
-        areaID: String,
+        areaID: String?,
         areaName: String?,
         attributionURL: String,
         countryCode: String,


### PR DESCRIPTION
Yesterday I ran into some parser errors, as the areaID is sometimes not present. So I made it optional.