### PR TITLE
Enable Swift 6 Mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -10,7 +10,8 @@ let package = Package(
         .iOS(.v13),
         .watchOS(.v6),
         .tvOS(.v13),
-        .macOS(.v11)
+        .macOS(.v11),
+        .visionOS(.v1)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -28,12 +28,11 @@ let package = Package(
         .testTarget(
             name: "OpenWeatherKitTests",
             dependencies: ["OpenWeatherKit"]),
-    ]
+    ],
+    swiftLanguageVersions: [.version("6"), .v5]
 )
 
 #if os(Linux)
 package.dependencies.append(.package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"))
 package.targets.first { $0.name == "OpenWeatherKit" }?.dependencies.append(.product(name: "AsyncHTTPClient", package: "async-http-client"))
 #endif
-
-

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ is nearly identical to Apple's [WeatherKit](https://developer.apple.com/document
 
 ## 💻 Supported Platforms
 
+Minimum Swift version of 5.9
+
 - iOS 13+
 - watchOS 6+
 - tvOS 13+
+- visionOS 1+
 - macOS 11+
 - Ubuntu 18.04+
 

--- a/Sources/OpenWeatherKit/Public/Celestial/MoonEvents.swift
+++ b/Sources/OpenWeatherKit/Public/Celestial/MoonEvents.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that represents lunar events.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct MoonEvents: Sendable {
 
     /// The moon phase.

--- a/Sources/OpenWeatherKit/Public/Celestial/MoonPhase.swift
+++ b/Sources/OpenWeatherKit/Public/Celestial/MoonPhase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An enumeration that specifies the moon phase kind.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 @frozen public enum MoonPhase : String, CustomStringConvertible, CaseIterable {
     enum CodingKeys: String, CodingKey {
         case new, waxingCrescent, firstQuarter, waxingGibbous, full, waningGibbous, waningCrescent

--- a/Sources/OpenWeatherKit/Public/Celestial/SunEvents.swift
+++ b/Sources/OpenWeatherKit/Public/Celestial/SunEvents.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An enumeration that represents dates of solar events, including sunrise, sunset, dawn, and dusk.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct SunEvents: Sendable {
 
     /// The time of astronomical sunrise when the sun’s center is 18° below the horizon.

--- a/Sources/OpenWeatherKit/Public/Characteristics/AlertSummary.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/AlertSummary.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// All information related to the weather alert
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct AlertSummary: Codable, Equatable, Sendable {
     public var name: String
     public var id: String

--- a/Sources/OpenWeatherKit/Public/Characteristics/AlertUrgency.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/AlertUrgency.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The urgency of the weather alert
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public enum AlertUrgency: String, Codable, Equatable, Sendable {
     // Take responsive action immediately.
     case immediate

--- a/Sources/OpenWeatherKit/Public/Characteristics/Certainty.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/Certainty.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The likelihood the weather alert event will happen
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public enum Certainty: String, Codable, Equatable, Sendable {
     
     // The event has already occurred or is ongoing.

--- a/Sources/OpenWeatherKit/Public/Characteristics/Precipitation.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/Precipitation.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The form of precipitation.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public enum Precipitation : String, CaseIterable, CustomStringConvertible, Hashable, Sendable {
 
     /// No precipitation.

--- a/Sources/OpenWeatherKit/Public/Characteristics/PressureTrend.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/PressureTrend.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The atmospheric pressure change over time.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public enum PressureTrend : String, CaseIterable, CustomStringConvertible, Hashable, Sendable {
 
     /// The pressure is rising.

--- a/Sources/OpenWeatherKit/Public/Characteristics/UVIndex.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/UVIndex.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The expected intensity of ultraviolet radiation from the sun.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct UVIndex: Sendable {
 
     /// The UV Index value.

--- a/Sources/OpenWeatherKit/Public/Characteristics/WeatherCondition.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/WeatherCondition.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A description of the current weather condition.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public enum WeatherCondition : String, CaseIterable, CustomStringConvertible, Hashable, Sendable {
 
     /// The kind of condition.

--- a/Sources/OpenWeatherKit/Public/Characteristics/WeatherSeverity.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/WeatherSeverity.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A description of the severity of the severe weather event.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public enum WeatherSeverity : String, Codable, CaseIterable, CustomStringConvertible, Hashable, Sendable {
 
     /// Specifies "minimal" or no threat to life or property.

--- a/Sources/OpenWeatherKit/Public/Characteristics/Wind.swift
+++ b/Sources/OpenWeatherKit/Public/Characteristics/Wind.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Contains wind data of speed, direction, and gust.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct Wind: Sendable {
 
     /// General indicator of wind direction, often referred to as "due north", "due south", etc.

--- a/Sources/OpenWeatherKit/Public/Forecast/DayWeather.swift
+++ b/Sources/OpenWeatherKit/Public/Forecast/DayWeather.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that represents the weather conditions for the day.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct DayWeather: Sendable {
 
     /// The start date of the day weather.

--- a/Sources/OpenWeatherKit/Public/Forecast/Forecast.swift
+++ b/Sources/OpenWeatherKit/Public/Forecast/Forecast.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A forecast collection for minute, hourly, and daily forecasts.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct Forecast<Element> : RandomAccessCollection, Codable, Equatable, Sendable where Element : Decodable, Element : Encodable, Element : Equatable, Element : Sendable {
     public init(forecast: [Element], metadata: WeatherMetadata) {
         self.forecast = forecast

--- a/Sources/OpenWeatherKit/Public/Forecast/HourWeather.swift
+++ b/Sources/OpenWeatherKit/Public/Forecast/HourWeather.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that represents the weather conditions for the hour.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct HourWeather: Sendable {
 
     /// The start date of the hour weather.

--- a/Sources/OpenWeatherKit/Public/Forecast/MinuteWeather.swift
+++ b/Sources/OpenWeatherKit/Public/Forecast/MinuteWeather.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that represents the next hour minute forecasts.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct MinuteWeather: Sendable {
 
     /// The start date of the minute weather.

--- a/Sources/OpenWeatherKit/Public/Forecast/WeatherAlert.swift
+++ b/Sources/OpenWeatherKit/Public/Forecast/WeatherAlert.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A weather alert issued for the requested location by a governmental authority.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct WeatherAlert: Sendable {
     /// The site for more details about the weather alert. Required link for attribution.
     public var detailsURL: URL

--- a/Sources/OpenWeatherKit/Public/Forecast/WeatherAvailability.swift
+++ b/Sources/OpenWeatherKit/Public/Forecast/WeatherAvailability.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that indicates the availability of data at the requested location.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct WeatherAvailability: Sendable {
 
     /// The minute forecast availability.

--- a/Sources/OpenWeatherKit/Public/Protocols/LocationProtocol.swift
+++ b/Sources/OpenWeatherKit/Public/Protocols/LocationProtocol.swift
@@ -16,7 +16,7 @@ extension CLLocation: LocationProtocol, @unchecked Sendable {
 #endif
 
 /// Defines the interface for a location
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public protocol LocationProtocol: Sendable {
     var latitude: Double { get }
     var longitude: Double { get }
@@ -24,7 +24,7 @@ public protocol LocationProtocol: Sendable {
     init(latitude: Double, longitude: Double)
 }
 
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct Location: LocationProtocol, Equatable, Codable, Sendable {
     public let latitude: Double
     public let longitude: Double

--- a/Sources/OpenWeatherKit/Public/Requests/CurrentWeather.swift
+++ b/Sources/OpenWeatherKit/Public/Requests/CurrentWeather.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that describes the current conditions observed at a location.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct CurrentWeather: Sendable {
     public init(
         date: Date,

--- a/Sources/OpenWeatherKit/Public/Requests/WeatherAttribution.swift
+++ b/Sources/OpenWeatherKit/Public/Requests/WeatherAttribution.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that defines the necessary information for attributing a weather data provider.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct WeatherAttribution {
 
     /// The weather data provider name.

--- a/Sources/OpenWeatherKit/Public/Requests/WeatherMetadata.swift
+++ b/Sources/OpenWeatherKit/Public/Requests/WeatherMetadata.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that provides additional weather information.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct WeatherMetadata: Sendable {
 
     /// The date of the weather data request.

--- a/Sources/OpenWeatherKit/Public/Requests/WeatherQuery.swift
+++ b/Sources/OpenWeatherKit/Public/Requests/WeatherQuery.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A structure that encapsulates a generic weather dataset request.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct WeatherQuery<T> {
     @usableFromInline
     let queryType: QueryType

--- a/Sources/OpenWeatherKit/Public/Weather.swift
+++ b/Sources/OpenWeatherKit/Public/Weather.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A model representing the aggregate weather data the caller requests.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public struct Weather: Sendable {
 
     /// The current weather forecast.

--- a/Sources/OpenWeatherKit/Public/WeatherError.swift
+++ b/Sources/OpenWeatherKit/Public/WeatherError.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An error WeatherKit returns.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 public enum WeatherError : LocalizedError, Equatable, Hashable {
     /// Could not find country code
     case countryCode

--- a/Sources/OpenWeatherKit/Public/WeatherService.swift
+++ b/Sources/OpenWeatherKit/Public/WeatherService.swift
@@ -15,11 +15,11 @@ import CoreLocation
 #endif
 
 /// Provides an interface for obtaining weather data.
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+@available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
 final public class WeatherService: Sendable {
 
     /// Establishes the configuration for weather requests.
-    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    @available(macOS 11, iOS 13, watchOS 6, tvOS 13, visionOS 1, *)
     public struct Configuration: Sendable {
         
         public enum Language: String, Sendable {


### PR DESCRIPTION
This change updates the swift tools version to 5.9 thereby opening up a couple of notable changes.

- Add visionOS 1.0+ support
- Enable Swift 6 language mode when it is available